### PR TITLE
Drop GStreamer VAAPI plugin

### DIFF
--- a/gstreamer.yml
+++ b/gstreamer.yml
@@ -20,7 +20,6 @@ config-opts:
   - -Dtests=disabled
   - -Dtools=disabled
   - -Dugly=enabled
-  - -Dvaapi=enabled
 
   - -Dgstreamer:check=disabled
 

--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -16,7 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
-
+  - --env=GST_PLUGIN_FEATURE_RANK=vah264dec:MAX,vah265dec:MAX,vavp8dec:MAX,vavp9dec:MAX,vaav1dec:MAX
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -17,6 +17,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --env=GST_PLUGIN_FEATURE_RANK=vah264dec:MAX,vah265dec:MAX,vavp8dec:MAX,vavp9dec:MAX,vaav1dec:MAX
+  
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
Gstreamer VAAPI plugin is already no more maintained and looks to be deprecated in future.
Is already possible to use Gstreamer VA plugins that are maintained and is vendor neutral, this can provide a best support in VAAPI hardware acceleration.
For default GStreamer VA Plugin doesn't contain a Feature rank defined,  for this work is necessary to force a env variable contains the feature rank 