### PR TITLE
Drop GStreamer VAAPI plugin in pr1 

### DIFF
--- a/gstreamer.yml
+++ b/gstreamer.yml
@@ -20,7 +20,6 @@ config-opts:
   - -Dtests=disabled
   - -Dtools=disabled
   - -Dugly=enabled
-  - -Dvaapi=enabled
 
   - -Dgstreamer:check=disabled
 

--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -16,7 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
-
+  - --env=GST_PLUGIN_FEATURE_RANK=vah264dec:MAX,vah265dec:MAX,vavp8dec:MAX,vavp9dec:MAX,vaav1dec:MAX
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -17,6 +17,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --env=GST_PLUGIN_FEATURE_RANK=vah264dec:MAX,vah265dec:MAX,vavp8dec:MAX,vavp9dec:MAX,vaav1dec:MAX
+  
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
This is the same at least but is for PR1 branch 
Gstreamer VAAPI plugin is not more maintained is better to use GStreamer VA plugin that are Vendor Neutral and is more maintained 