### PR TITLE
Use xxhash module from runtime and more

### DIFF
--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -36,22 +36,12 @@ cleanup:
   - '*.a'
 
 modules:
-  - name: xxHash
-    buildsystem: simple
-    sources:
-      - type: archive
-        url: https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz
-        sha256: aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80
-    build-commands:
-      - make PREFIX=/app
-      - make PREFIX=/app install
-
   - name: daikhan
-    builddir: true
     buildsystem: meson
+    builddir: true
+    config-opts:
+      - -Dprofile=stable
     sources:
       - type: archive
         url: https://gitlab.com/daikhan/daikhan/-/archive/0.1-alpha6/daikhan-0.1-alpha6.tar.bz2
         sha256: cecf19d3f2fa972cbd2b022332b414b4426880f3405d742f39499ed793261e38
-    config-opts:
-      - -Dprofile=stable

--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -13,28 +13,6 @@ finish-args:
   - --socket=pulseaudio
   - --own-name=org.mpris.MediaPlayer2.daikhan
 
-cleanup:
-  - /etc
-  - /include
-  - /libexec
-  - /lib/cmake
-  - /lib/girepository-1.0
-  - /lib/gstreamer-1.0/include
-  - /lib/pkgconfig
-  - /man
-  - /share/aclocal
-  - /share/doc
-  - /share/gir-1.0
-  - /share/gstreamer-1.0
-  - /share/gst-plugins-base
-  - /share/gtk-doc
-  - /share/info
-  - /share/man
-  - /share/pkgconfig
-  - /share/vpl/examples
-  - '*.la'
-  - '*.a'
-
 modules:
   - name: daikhan
     buildsystem: meson


### PR DESCRIPTION
### Use xxhash module from runtime and more

GNOME runtime version 49 (based on the Freedesktop runtime
version **25.08**) appears to provide the **xxhash** module.

In most cases, you don't need to build this module separately,
unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/io.gitlab.daikhan.stable/issues/52

### Drop redundant cleanup commands

We don't need them since the related modules are already gone.