### PR TITLE
Revert "Update GNOME Runtime to 50"

### DIFF
--- a/io.gitlab.daikhan.stable.yml
+++ b/io.gitlab.daikhan.stable.yml
@@ -1,7 +1,7 @@
 app-id: io.gitlab.daikhan.stable
 command: daikhan
 runtime: org.gnome.Platform
-runtime-version: "50"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 
 finish-args:


### PR DESCRIPTION
There have been some regressions that I have experienced

This reverts commit 2dc3042bbdab4537f342826ae8064eea16ad28cd.